### PR TITLE
Fix conflicting file providers

### DIFF
--- a/tool-timber/src/main/AndroidManifest.xml
+++ b/tool-timber/src/main/AndroidManifest.xml
@@ -37,7 +37,7 @@
 
         <provider
             android:name=".SentinelLogsProvider"
-            android:authorities="com.infinum.sentinel.logprovider"
+            android:authorities="${applicationId}.sentinel.logprovider"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data


### PR DESCRIPTION
## :page_facing_up: Context
Version 1.2.9 added a FileProvider with authority that wasn't unique per app, that resulted in users being unable to install a second app which Sentinel v1.2.9

## :pencil: Changes
Use `${applicationId}.sentinel.logprovider` in Timber Tool FileProvider authorities, instead of `com.infinum.sentinel.logprovider`

## :hammer_and_wrench: How to test
Provided you already have an app using Sentinel 1.2.9 installed (e.g. the sample app), try to install another app using Sentinel 1.2.9, without the fix the installation should fail with `INSTALL_FAILED_CONFLICTING_PROVIDER ` error. With the fix, the error shouldn't be present anymore.

Tested on Pixel 6, Android 13.

## :stopwatch: Next steps
Release new version