### PR TITLE
Fix Java version for Github action code analysis 

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -15,6 +15,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Set up Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: "adopt"
+          java-version: 17
       - name: Save Gradle Caches
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
CI is broken because Android plugin "com.android.application" doesn't work with Java 11 anymore.