### PR TITLE
Fix: Add Android 13 notification permission support

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,8 @@ _Plain_ formatter is selected by default, but selecting any other is persisted b
 ## Crash monitor
 
 _Sentinel_ has a built in default uncaught exception handler and ANR observer. If switched on in
-settings, it will notify both in a form of a notification.  
+settings, it will notify both in a form of a notification. Note that from Android 13 you need to give permission 
+to the app to show notifications.
 Once tapped on this notification, a screen with details is shown. A complete list of crashes is
 persisted between sessions and available on demand.    
 Methods to react on these crashes in a graceful way are provided in _Sentinel_.

--- a/sentinel/src/main/AndroidManifest.xml
+++ b/sentinel/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
     <application>
 
         <activity

--- a/sentinel/src/main/kotlin/com/infinum/sentinel/ui/settings/SettingsEvent.kt
+++ b/sentinel/src/main/kotlin/com/infinum/sentinel/ui/settings/SettingsEvent.kt
@@ -27,4 +27,6 @@ internal sealed class SettingsEvent {
     data class CertificateMonitorChanged(
         val value: CertificateMonitorEntity
     ) : SettingsEvent()
+
+    object PermissionsCheck : SettingsEvent()
 }

--- a/sentinel/src/main/kotlin/com/infinum/sentinel/ui/settings/SettingsViewModel.kt
+++ b/sentinel/src/main/kotlin/com/infinum/sentinel/ui/settings/SettingsViewModel.kt
@@ -124,6 +124,7 @@ internal class SettingsViewModel(
                     anrObserver.stop()
                 }
             }
+            emitEvent(SettingsEvent.PermissionsCheck)
         }
 
     fun updateCertificatesMonitor(entity: CertificateMonitorEntity) {

--- a/sentinel/src/main/kotlin/com/infinum/sentinel/ui/shared/notification/SystemNotificationFactory.kt
+++ b/sentinel/src/main/kotlin/com/infinum/sentinel/ui/shared/notification/SystemNotificationFactory.kt
@@ -29,6 +29,14 @@ internal class SystemNotificationFactory(
     private val notificationManager: NotificationManager =
         context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
+    private fun canShowNotifications(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            notificationManager.areNotificationsEnabled()
+        } else {
+            true
+        }
+    }
+
     init {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val notificationChannel = NotificationChannel(
@@ -117,6 +125,9 @@ internal class SystemNotificationFactory(
         content: String,
         intents: Array<Intent>,
     ) {
+        if (!canShowNotifications()) {
+            return
+        }
         val builder = NotificationCompat.Builder(context, NOTIFICATIONS_CHANNEL_ID)
             .setContentIntent(buildPendingIntent(intents))
             .setLocalOnly(true)
@@ -139,6 +150,7 @@ internal class SystemNotificationFactory(
             when {
                 Build.VERSION.SDK_INT >= Build.VERSION_CODES.S ->
                     PendingIntent.FLAG_MUTABLE
+
                 else -> PendingIntent.FLAG_CANCEL_CURRENT
             }
         )

--- a/sentinel/src/main/res/values/themes.xml
+++ b/sentinel/src/main/res/values/themes.xml
@@ -28,6 +28,8 @@
         <item name="colorOnSurfaceInverse">@color/sentinel_inverseOnSurface</item>
         <item name="colorSurfaceInverse">@color/sentinel_inverseSurface</item>
         <item name="colorPrimaryInverse">@color/sentinel_primaryInverse</item>
+        <item name="snackbarStyle">@style/Sentinel.Snackbar</item>
+        <item name="snackbarButtonStyle">@style/Sentinel.Snackbar.TextButton</item>
     </style>
 
     <style name="Sentinel.Theme" parent="Sentinel.BaseTheme">
@@ -89,4 +91,14 @@
     <style name="Sentinel.Animation" parent="@android:style/Animation">
         <item name="android:windowExitAnimation">@android:anim/fade_out</item>
     </style>
+
+    <style name="Sentinel.Snackbar" parent="@style/Widget.MaterialComponents.Snackbar">
+        <item name="android:background">@color/sentinel_onBackground</item>
+    </style>
+
+    <style name="Sentinel.Snackbar.TextButton" parent="@style/Widget.MaterialComponents.Button.TextButton.Snackbar">
+        <item name="android:textColor">@color/sentinel_primary</item>
+    </style>
+
+
 </resources>


### PR DESCRIPTION
## :camera: Screenshots
<img src='https://github.com/infinum/android-sentinel/assets/20267231/09885b33-9a78-430c-96dd-2e82ca9f99bd' width='525'>
<img src='https://github.com/infinum/android-sentinel/assets/20267231/ce7e05ab-aaf6-4515-a098-df0c7047f886' width='525'>
<img src='https://github.com/infinum/android-sentinel/assets/20267231/f835202c-759d-45c2-b2d7-225afa57b140' width='525'>

## :page_facing_up: Context
https://github.com/infinum/android-sentinel/issues/45

## :pencil: Changes
Updated readme to let users know that from Android 13 they need to turn on notifications on app level if they want to see them.
Added notifications permission to manifest.
Added logic to check if notifications are enabled before creating notifications.
Added check for notifications permission in settings. (currently only for crash monitor, if we need to add somewhere else, just ping me)

## :no_entry_sign: Breaking
Shouldn't be

## :hammer_and_wrench: How to test
Simply try sample app on Android 13+ device.

## :stopwatch: Next steps
Taking a look at other issues