### PR TITLE
Fix Java 17 on CI jobs

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -38,6 +38,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Set up Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: "adopt"
+          java-version: 17
       - name: Save Gradle Caches
         uses: actions/cache@v2
         with:
@@ -56,6 +61,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Set up Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: "adopt"
+          java-version: 17
       - name: Save Gradle Caches
         uses: actions/cache@v2
         with:
@@ -73,6 +83,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Set up Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: "adopt"
+          java-version: 17
       - name: Save Gradle Caches
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
CI jobs are failing because they need Java 17. Previous fix only fixed on job (lint)