### PR TITLE
Fix: Investigate initializer errors

### DIFF
--- a/sentinel-no-op/src/main/AndroidManifest.xml
+++ b/sentinel-no-op/src/main/AndroidManifest.xml
@@ -11,11 +11,6 @@
             <meta-data
                 android:name="com.infinum.sentinel.SentinelInitializer"
                 android:value="androidx.startup" />
-
-            <meta-data
-                android:name="androidx.work.WorkManagerInitializer"
-                android:value="androidx.startup"
-                tools:node="remove" />
         </provider>
 
     </application>

--- a/sentinel-no-op/src/main/AndroidManifest.xml
+++ b/sentinel-no-op/src/main/AndroidManifest.xml
@@ -11,6 +11,11 @@
             <meta-data
                 android:name="com.infinum.sentinel.SentinelInitializer"
                 android:value="androidx.startup" />
+
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
         </provider>
 
     </application>

--- a/sentinel/src/main/AndroidManifest.xml
+++ b/sentinel/src/main/AndroidManifest.xml
@@ -112,13 +112,7 @@
             <meta-data
                 android:name="com.infinum.sentinel.SentinelInitializer"
                 android:value="androidx.startup" />
-        </provider>
 
-        <provider
-            android:name="androidx.startup.InitializationProvider"
-            android:authorities="${applicationId}.androidx-startup"
-            android:exported="false"
-            tools:node="merge">
             <meta-data
                 android:name="androidx.work.WorkManagerInitializer"
                 android:value="androidx.startup"

--- a/sentinel/src/main/AndroidManifest.xml
+++ b/sentinel/src/main/AndroidManifest.xml
@@ -112,7 +112,13 @@
             <meta-data
                 android:name="com.infinum.sentinel.SentinelInitializer"
                 android:value="androidx.startup" />
+        </provider>
 
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
             <meta-data
                 android:name="androidx.work.WorkManagerInitializer"
                 android:value="androidx.startup"

--- a/sentinel/src/main/AndroidManifest.xml
+++ b/sentinel/src/main/AndroidManifest.xml
@@ -13,10 +13,10 @@
             android:name=".ui.main.SentinelActivity"
             android:exported="true"
             android:label="@string/sentinel_name"
+            android:permission="com.infinum.sentinel.permission.ACCESS_SENTINEL"
             android:taskAffinity="com.infinum.sentinel"
-            android:theme="@style/Sentinel.Theme"
-            android:permission="com.infinum.sentinel.permission.ACCESS_SENTINEL">
-        <meta-data
+            android:theme="@style/Sentinel.Theme">
+            <meta-data
                 android:name="@string/sentinel_infinum_monitored"
                 android:value="false" />
         </activity>
@@ -117,11 +117,6 @@
             <meta-data
                 android:name="com.infinum.sentinel.SentinelInitializer"
                 android:value="androidx.startup" />
-
-            <meta-data
-                android:name="androidx.work.WorkManagerInitializer"
-                android:value="androidx.startup"
-                tools:node="remove" />
         </provider>
 
     </application>

--- a/sentinel/src/main/kotlin/com/infinum/sentinel/di/LibraryComponents.kt
+++ b/sentinel/src/main/kotlin/com/infinum/sentinel/di/LibraryComponents.kt
@@ -42,6 +42,7 @@ internal object LibraryComponents {
             tools.filterIsInstance<CertificateTool>().firstOrNull()?.userCertificates.orEmpty(),
             onTriggered
         )
+        WorkManagerInitializer.init(domainComponent)
         domainComponent.setup()
     }
 

--- a/sentinel/src/main/kotlin/com/infinum/sentinel/di/WorkManagerInitializer.kt
+++ b/sentinel/src/main/kotlin/com/infinum/sentinel/di/WorkManagerInitializer.kt
@@ -1,0 +1,14 @@
+package com.infinum.sentinel.di
+
+import com.infinum.sentinel.di.component.DomainComponent
+import com.infinum.sentinel.ui.certificates.observer.CertificateCheckWorker
+import com.infinum.sentinel.ui.certificates.observer.DelegateWorker
+import com.infinum.sentinel.ui.certificates.observer.SentinelWorkerFactory
+
+internal object WorkManagerInitializer {
+
+    fun init(domainComponent: DomainComponent) {
+        DelegateWorker.workerFactories[CertificateCheckWorker.NAME] =
+            SentinelWorkerFactory(domainComponent.collectors, domainComponent.notificationFactory)
+    }
+}

--- a/sentinel/src/main/kotlin/com/infinum/sentinel/di/component/DomainComponent.kt
+++ b/sentinel/src/main/kotlin/com/infinum/sentinel/di/component/DomainComponent.kt
@@ -48,7 +48,9 @@ import com.infinum.sentinel.extensions.sizeTree
 import com.infinum.sentinel.ui.bundles.callbacks.BundleMonitorActivityCallbacks
 import com.infinum.sentinel.ui.bundles.callbacks.BundleMonitorNotificationCallbacks
 import com.infinum.sentinel.ui.bundles.details.BundleDetailsActivity
+import com.infinum.sentinel.ui.certificates.observer.CertificateCheckWorker
 import com.infinum.sentinel.ui.certificates.observer.CertificatesObserver
+import com.infinum.sentinel.ui.certificates.observer.DelegateWorker
 import com.infinum.sentinel.ui.certificates.observer.SentinelWorkManager
 import com.infinum.sentinel.ui.certificates.observer.SentinelWorkerFactory
 import com.infinum.sentinel.ui.crash.anr.SentinelAnrObserver
@@ -160,7 +162,9 @@ internal abstract class DomainComponent(
     @Provides
     @DomainScope
     fun sentinelWorkerFactory(): SentinelWorkerFactory =
-        SentinelWorkerFactory(collectors, notificationFactory)
+        SentinelWorkerFactory(collectors, notificationFactory).also {
+            DelegateWorker.workerFactories[CertificateCheckWorker.NAME] = it
+        }
 
     @Provides
     @DomainScope

--- a/sentinel/src/main/kotlin/com/infinum/sentinel/di/component/DomainComponent.kt
+++ b/sentinel/src/main/kotlin/com/infinum/sentinel/di/component/DomainComponent.kt
@@ -48,11 +48,8 @@ import com.infinum.sentinel.extensions.sizeTree
 import com.infinum.sentinel.ui.bundles.callbacks.BundleMonitorActivityCallbacks
 import com.infinum.sentinel.ui.bundles.callbacks.BundleMonitorNotificationCallbacks
 import com.infinum.sentinel.ui.bundles.details.BundleDetailsActivity
-import com.infinum.sentinel.ui.certificates.observer.CertificateCheckWorker
 import com.infinum.sentinel.ui.certificates.observer.CertificatesObserver
-import com.infinum.sentinel.ui.certificates.observer.DelegateWorker
 import com.infinum.sentinel.ui.certificates.observer.SentinelWorkManager
-import com.infinum.sentinel.ui.certificates.observer.SentinelWorkerFactory
 import com.infinum.sentinel.ui.crash.anr.SentinelAnrObserver
 import com.infinum.sentinel.ui.crash.anr.SentinelAnrObserverRunnable
 import com.infinum.sentinel.ui.crash.anr.SentinelUiAnrObserver
@@ -92,8 +89,6 @@ internal abstract class DomainComponent(
     abstract val certificatesObserver: CertificatesObserver
 
     abstract val sentinelAnrObserver: SentinelAnrObserver
-
-    abstract val sentinelWorkerFactory: SentinelWorkerFactory
 
     abstract val sentinelWorkManager: SentinelWorkManager
 
@@ -161,15 +156,8 @@ internal abstract class DomainComponent(
 
     @Provides
     @DomainScope
-    fun sentinelWorkerFactory(): SentinelWorkerFactory =
-        SentinelWorkerFactory(collectors, notificationFactory).also {
-            DelegateWorker.workerFactories[CertificateCheckWorker.NAME] = it
-        }
-
-    @Provides
-    @DomainScope
     fun sentinelWorkManager(): SentinelWorkManager =
-        SentinelWorkManager(context, sentinelWorkerFactory)
+        SentinelWorkManager(context)
 
     @Provides
     @DomainScope

--- a/sentinel/src/main/kotlin/com/infinum/sentinel/ui/certificates/observer/DelegateWorker.kt
+++ b/sentinel/src/main/kotlin/com/infinum/sentinel/ui/certificates/observer/DelegateWorker.kt
@@ -34,7 +34,7 @@ internal class DelegateWorker(
         } else {
             val errorMessage = "No delegateWorker available for $workerId" +
                 " with workerClassName of $workerClassName. Is the " +
-                "RouterWorker.workerFactories populated correctly?"
+                "DelegateWorker.workerFactories populated correctly?"
 
             Log.w("Sentinel", errorMessage)
 

--- a/sentinel/src/main/kotlin/com/infinum/sentinel/ui/certificates/observer/DelegateWorker.kt
+++ b/sentinel/src/main/kotlin/com/infinum/sentinel/ui/certificates/observer/DelegateWorker.kt
@@ -25,11 +25,11 @@ internal class DelegateWorker(
         parameters.inputData.getString(WORKER_CLASS_NAME) ?: ""
     private val workerId = parameters.inputData.getString(WORKER_ID)
     private val delegateWorkerFactory = workerFactories[workerId]
-    private val delegateWorker = delegateWorkerFactory?.createWorker(appContext, workerClassName, parameters)
+    private val delegatedWorker = delegateWorkerFactory?.createWorker(appContext, workerClassName, parameters)
 
     override fun startWork(): ListenableFuture<Result> {
-        return if (delegateWorker != null) {
-            delegateWorker.startWork()
+        return if (delegatedWorker != null) {
+            delegatedWorker.startWork()
         } else {
             val errorMessage = "No delegateWorker available for $workerId" +
                 " with workerClassName of $workerClassName. Is the " +

--- a/sentinel/src/main/kotlin/com/infinum/sentinel/ui/certificates/observer/DelegateWorker.kt
+++ b/sentinel/src/main/kotlin/com/infinum/sentinel/ui/certificates/observer/DelegateWorker.kt
@@ -35,19 +35,7 @@ internal class DelegateWorker(
             val errorMessage = "No delegateWorker available for $workerId" +
                 " with workerClassName of $workerClassName. Is the " +
                 "DelegateWorker.workerFactories populated correctly?"
-
-            Log.w("Sentinel", errorMessage)
-
-            val errorData = Data.Builder().putString("Reason", errorMessage).build()
-
-            object : ListenableFuture<Result> {
-                override fun isDone(): Boolean = true
-                override fun get(): Result = Result.failure(errorData)
-                override fun get(timeout: Long, unit: TimeUnit): Result = Result.failure(errorData)
-                override fun cancel(mayInterruptIfRunning: Boolean): Boolean = false
-                override fun isCancelled(): Boolean = false
-                override fun addListener(listener: Runnable, executor: Executor) = listener.run()
-            }
+            throw IllegalStateException(errorMessage)
         }
     }
 

--- a/sentinel/src/main/kotlin/com/infinum/sentinel/ui/certificates/observer/DelegateWorker.kt
+++ b/sentinel/src/main/kotlin/com/infinum/sentinel/ui/certificates/observer/DelegateWorker.kt
@@ -1,0 +1,69 @@
+package com.infinum.sentinel.ui.certificates.observer
+
+import android.content.Context
+import android.util.Log
+import androidx.work.Data
+import androidx.work.ListenableWorker
+import androidx.work.WorkerFactory
+import androidx.work.WorkerParameters
+import com.google.common.util.concurrent.ListenableFuture
+import com.infinum.sentinel.ui.shared.Constants.Keys.WORKER_CLASS_NAME
+import com.infinum.sentinel.ui.shared.Constants.Keys.WORKER_ID
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
+
+/**
+ * A worker to delegate work requests from within the library to workers
+ * that require factories with custom dependencies.
+ */
+internal class DelegateWorker(
+    appContext: Context,
+    parameters: WorkerParameters,
+) : ListenableWorker(appContext, parameters) {
+
+    private val workerClassName =
+        parameters.inputData.getString(WORKER_CLASS_NAME) ?: ""
+    private val workerId = parameters.inputData.getString(WORKER_ID)
+    private val delegateWorkerFactory = workerFactories[workerId]
+    private val delegateWorker = delegateWorkerFactory?.createWorker(appContext, workerClassName, parameters)
+
+    override fun startWork(): ListenableFuture<Result> {
+        return if (delegateWorker != null) {
+            delegateWorker.startWork()
+        } else {
+            val errorMessage = "No delegateWorker available for $workerId" +
+                " with workerClassName of $workerClassName. Is the " +
+                "RouterWorker.workerFactories populated correctly?"
+
+            Log.w("Sentinel", errorMessage)
+
+            val errorData = Data.Builder().putString("Reason", errorMessage).build()
+
+            object : ListenableFuture<Result> {
+                override fun isDone(): Boolean = true
+                override fun get(): Result = Result.failure(errorData)
+                override fun get(timeout: Long, unit: TimeUnit): Result = Result.failure(errorData)
+                override fun cancel(mayInterruptIfRunning: Boolean): Boolean = false
+                override fun isCancelled(): Boolean = false
+                override fun addListener(listener: Runnable, executor: Executor) = listener.run()
+            }
+        }
+    }
+
+    companion object {
+        const val DELEGATE_WORKER_ID = "com.infinum.sentinel.ui.certificates.observer.CertificateCheckWorker"
+
+        val workerFactories = object : AbstractMutableMap<String, WorkerFactory>() {
+
+            private val backingWorkerMap = mutableMapOf<String, WorkerFactory>()
+
+            // should be invoked only from the main thread
+            override fun put(key: String, value: WorkerFactory): WorkerFactory? {
+                return backingWorkerMap.put(key, value)
+            }
+
+            override val entries: MutableSet<MutableMap.MutableEntry<String, WorkerFactory>>
+                get() = backingWorkerMap.entries
+        }
+    }
+}

--- a/sentinel/src/main/kotlin/com/infinum/sentinel/ui/certificates/observer/DelegateWorker.kt
+++ b/sentinel/src/main/kotlin/com/infinum/sentinel/ui/certificates/observer/DelegateWorker.kt
@@ -1,17 +1,13 @@
 package com.infinum.sentinel.ui.certificates.observer
 
 import android.content.Context
-import android.util.Log
 import androidx.annotation.UiThread
-import androidx.work.Data
 import androidx.work.ListenableWorker
 import androidx.work.WorkerFactory
 import androidx.work.WorkerParameters
 import com.google.common.util.concurrent.ListenableFuture
 import com.infinum.sentinel.ui.shared.Constants.Keys.WORKER_CLASS_NAME
 import com.infinum.sentinel.ui.shared.Constants.Keys.WORKER_ID
-import java.util.concurrent.Executor
-import java.util.concurrent.TimeUnit
 
 /**
  * A worker to delegate work requests from within the library to workers

--- a/sentinel/src/main/kotlin/com/infinum/sentinel/ui/certificates/observer/DelegateWorker.kt
+++ b/sentinel/src/main/kotlin/com/infinum/sentinel/ui/certificates/observer/DelegateWorker.kt
@@ -2,6 +2,7 @@ package com.infinum.sentinel.ui.certificates.observer
 
 import android.content.Context
 import android.util.Log
+import androidx.annotation.UiThread
 import androidx.work.Data
 import androidx.work.ListenableWorker
 import androidx.work.WorkerFactory
@@ -57,7 +58,7 @@ internal class DelegateWorker(
 
             private val backingWorkerMap = mutableMapOf<String, WorkerFactory>()
 
-            // should be invoked only from the main thread
+            @UiThread
             override fun put(key: String, value: WorkerFactory): WorkerFactory? {
                 return backingWorkerMap.put(key, value)
             }

--- a/sentinel/src/main/kotlin/com/infinum/sentinel/ui/certificates/observer/SentinelWorkManager.kt
+++ b/sentinel/src/main/kotlin/com/infinum/sentinel/ui/certificates/observer/SentinelWorkManager.kt
@@ -10,7 +10,6 @@ import androidx.work.NetworkType
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
-import androidx.work.WorkerFactory
 import androidx.work.workDataOf
 import com.infinum.sentinel.BuildConfig
 import com.infinum.sentinel.data.models.local.CertificateMonitorEntity
@@ -29,7 +28,6 @@ import me.tatarka.inject.annotations.Inject
 @Inject
 internal class SentinelWorkManager(
     private val context: Context,
-    private val workerFactory: WorkerFactory
 ) {
 
     companion object {

--- a/sentinel/src/main/kotlin/com/infinum/sentinel/ui/certificates/observer/SentinelWorkManager.kt
+++ b/sentinel/src/main/kotlin/com/infinum/sentinel/ui/certificates/observer/SentinelWorkManager.kt
@@ -37,13 +37,15 @@ internal class SentinelWorkManager(
     }
 
     init {
-        WorkManager.initialize(
-            context,
-            Configuration.Builder()
-                .setMinimumLoggingLevel(android.util.Log.INFO)
-                .setWorkerFactory(workerFactory)
-                .build()
-        )
+        if (WorkManager.isInitialized().not()) {
+            WorkManager.initialize(
+                context,
+                Configuration.Builder()
+                    .setMinimumLoggingLevel(android.util.Log.INFO)
+                    .setWorkerFactory(workerFactory)
+                    .build()
+            )
+        }
     }
 
     @RequiresApi(Build.VERSION_CODES.O)

--- a/sentinel/src/main/kotlin/com/infinum/sentinel/ui/certificates/observer/SentinelWorkManager.kt
+++ b/sentinel/src/main/kotlin/com/infinum/sentinel/ui/certificates/observer/SentinelWorkManager.kt
@@ -85,7 +85,6 @@ internal class SentinelWorkManager(
                     )
                     .build()
             )
-
     }
 
     fun certificatesCheckState(): Flow<Boolean> =

--- a/sentinel/src/main/kotlin/com/infinum/sentinel/ui/certificates/observer/SentinelWorkManager.kt
+++ b/sentinel/src/main/kotlin/com/infinum/sentinel/ui/certificates/observer/SentinelWorkManager.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.lifecycle.asFlow
-import androidx.work.Configuration
 import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.NetworkType
@@ -36,18 +35,6 @@ internal class SentinelWorkManager(
     companion object {
         private const val DEBUG_INTERVAL = 15L
         private const val RELEASE_INTERVAL = 1440L
-    }
-
-    init {
-        if (WorkManager.isInitialized().not()) {
-            WorkManager.initialize(
-                context,
-                Configuration.Builder()
-                    .setMinimumLoggingLevel(android.util.Log.INFO)
-                    .setWorkerFactory(workerFactory)
-                    .build()
-            )
-        }
     }
 
     @RequiresApi(Build.VERSION_CODES.O)

--- a/sentinel/src/main/kotlin/com/infinum/sentinel/ui/shared/Constants.kt
+++ b/sentinel/src/main/kotlin/com/infinum/sentinel/ui/shared/Constants.kt
@@ -14,5 +14,7 @@ internal object Constants {
         const val NOTIFY_TO_EXPIRE: String = "KEY_NOTIFY_TO_EXPIRE"
         const val EXPIRE_IN_AMOUNT: String = "KEY_EXPIRE_IN_AMOUNT"
         const val EXPIRE_IN_UNIT: String = "KEY_EXPIRE_IN_UNIT"
+        const val WORKER_CLASS_NAME = "WORKER_CLASS_NAME"
+        const val WORKER_ID = "WORKER_ID"
     }
 }


### PR DESCRIPTION
## :camera: Screenshots
<!-- Show us what you've changed, we love images. -->

## :page_facing_up: Context
<!-- Why did you change something? Is there an [issue](https://github.com/infinum/android-sentinel/issues) to link here? Or an external link? -->
When user wouldn't include all tools into `build.gradle` file, it would cause crash "WorkManager is already initialized". It seems problem was in how `AndroidManifests` were merged.
I am adding Antun as optional reviewer since he was there when crashes happened 😄 .

## :pencil: Changes
<!-- Which code did you change? How? -->
By removing 2 startup providers and merging them under one with separate meta-data, crashes are gone. Same provider had to be put inside of no-op module as well, otherwise it would cause NPE. Other modules didn't have to be touched.

## :paperclip: Related PR
<!-- PR that blocks this one, or the ones blocked by this PR -->

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? -->

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->

## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->