### PR TITLE
Update README.md for no-op dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Then add the following dependencies in your app `build.gradle` or `build.gradle.
 ```groovy
 def sentinelVersion = "1.3.3"
 debugImplementation "com.infinum.sentinel:sentinel:$sentinelVersion"
-releaseImplementation "com.infinum.sentinel:sentinel-noop:$sentinelVersion"
+releaseImplementation "com.infinum.sentinel:sentinel-no-op:$sentinelVersion"
 ```
 
 **KotlinDSL**


### PR DESCRIPTION
## :camera: Screenshots
/

## :page_facing_up: Context
/

## :pencil: Changes
According to mavencentral  the no op dependency has the sentinel-no-op coordinate: https://mvnrepository.com/artifact/com.infinum.sentinel/sentinel-no-op/1.3.3

## :paperclip: Related PR
/

## :no_entry_sign: Breaking
/

## :hammer_and_wrench: How to test
/

## :stopwatch: Next steps
/