### PR TITLE
Add date format to exported logs

### DIFF
--- a/tool-timber/src/main/kotlin/com/infinum/sentinel/SentinelFileTree.kt
+++ b/tool-timber/src/main/kotlin/com/infinum/sentinel/SentinelFileTree.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.infinum.sentinel.ui.logger.models.BaseEntry
 import com.infinum.sentinel.ui.logger.models.FlowBuffer
 import com.infinum.sentinel.ui.logger.models.Level
+import com.infinum.sentinel.ui.shared.Constants.LOG_DATE_TIME_FORMAT
 import com.infinum.sentinel.ui.shared.LogFileResolver
 import java.io.File
 import java.text.SimpleDateFormat
@@ -22,7 +23,7 @@ internal class SentinelFileTree(
     private val logFileResolver = LogFileResolver(context)
 
     override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
-        val dateTimeFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss. SSSZ", Locale.getDefault())
+        val dateTimeFormat = SimpleDateFormat(LOG_DATE_TIME_FORMAT, Locale.getDefault())
 
         MainScope().launch {
             withContext(Dispatchers.IO) {

--- a/tool-timber/src/main/kotlin/com/infinum/sentinel/SentinelFileTree.kt
+++ b/tool-timber/src/main/kotlin/com/infinum/sentinel/SentinelFileTree.kt
@@ -6,7 +6,8 @@ import com.infinum.sentinel.ui.logger.models.FlowBuffer
 import com.infinum.sentinel.ui.logger.models.Level
 import com.infinum.sentinel.ui.shared.LogFileResolver
 import java.io.File
-import java.util.Calendar
+import java.text.SimpleDateFormat
+import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
@@ -21,6 +22,8 @@ internal class SentinelFileTree(
     private val logFileResolver = LogFileResolver(context)
 
     override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+        val dateTimeFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss. SSSZ", Locale.getDefault())
+
         MainScope().launch {
             withContext(Dispatchers.IO) {
                 val entry = Entry(
@@ -34,7 +37,7 @@ internal class SentinelFileTree(
                 buffer.enqueue(entry)
 
                 val file: File = logFileResolver.createOrOpenFile()
-                val line = entry.asLineString()
+                val line = entry.asLineString(dateTimeFormat)
 
                 file.appendText(line)
             }

--- a/tool-timber/src/main/kotlin/com/infinum/sentinel/TimberInitializer.kt
+++ b/tool-timber/src/main/kotlin/com/infinum/sentinel/TimberInitializer.kt
@@ -3,7 +3,6 @@ package com.infinum.sentinel
 import android.content.Context
 import androidx.startup.Initializer
 import com.infinum.sentinel.ui.logger.models.FlowBuffer
-import kotlinx.coroutines.MainScope
 import timber.log.Timber
 
 public class TimberInitializer : Initializer<Class<TimberInitializer>> {

--- a/tool-timber/src/main/kotlin/com/infinum/sentinel/ui/logger/LoggerActivity.kt
+++ b/tool-timber/src/main/kotlin/com/infinum/sentinel/ui/logger/LoggerActivity.kt
@@ -36,7 +36,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
-
 public class LoggerActivity : AppCompatActivity() {
 
     private companion object {
@@ -94,21 +93,21 @@ public class LoggerActivity : AppCompatActivity() {
         with(binding) {
             toolbar.setNavigationOnClickListener { finish() }
             toolbar.subtitle = (
-                    packageManager.getApplicationLabel(
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                            packageManager.getApplicationInfo(
-                                packageName,
-                                PackageManager.ApplicationInfoFlags.of(PackageManager.GET_META_DATA.toLong())
-                            )
-                        } else {
-                            @Suppress("DEPRECATION")
-                            packageManager.getApplicationInfo(
-                                packageName,
-                                PackageManager.GET_META_DATA
-                            )
-                        }
-                    ) as? String
-                    ) ?: getString(R.string.sentinel_name)
+                packageManager.getApplicationLabel(
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                        packageManager.getApplicationInfo(
+                            packageName,
+                            PackageManager.ApplicationInfoFlags.of(PackageManager.GET_META_DATA.toLong())
+                        )
+                    } else {
+                        @Suppress("DEPRECATION")
+                        packageManager.getApplicationInfo(
+                            packageName,
+                            PackageManager.GET_META_DATA
+                        )
+                    }
+                ) as? String
+                ) ?: getString(R.string.sentinel_name)
             toolbar.setOnMenuItemClickListener {
                 when (it.itemId) {
                     R.id.search -> {

--- a/tool-timber/src/main/kotlin/com/infinum/sentinel/ui/logger/LoggerAdapter.kt
+++ b/tool-timber/src/main/kotlin/com/infinum/sentinel/ui/logger/LoggerAdapter.kt
@@ -5,11 +5,15 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
 import com.infinum.sentinel.SentinelFileTree
 import com.infinum.sentinel.databinding.SentinelItemLogBinding
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 internal class LoggerAdapter(
     private val onListChanged: (Boolean) -> Unit,
     private val onClick: (SentinelFileTree.Entry) -> Unit
 ) : ListAdapter<SentinelFileTree.Entry, LoggerViewHolder>(LoggerDiffUtil()) {
+
+    private val dateTimeFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss. SSSZ", Locale.getDefault())
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): LoggerViewHolder =
         LoggerViewHolder(
@@ -21,7 +25,11 @@ internal class LoggerAdapter(
         )
 
     override fun onBindViewHolder(holder: LoggerViewHolder, position: Int) {
-        holder.bind(getItem(position), onClick)
+        holder.bind(
+            item = getItem(position),
+            dateTimeFormat = dateTimeFormat,
+            onClick = onClick
+        )
     }
 
     override fun onViewRecycled(holder: LoggerViewHolder) {

--- a/tool-timber/src/main/kotlin/com/infinum/sentinel/ui/logger/LoggerAdapter.kt
+++ b/tool-timber/src/main/kotlin/com/infinum/sentinel/ui/logger/LoggerAdapter.kt
@@ -5,6 +5,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
 import com.infinum.sentinel.SentinelFileTree
 import com.infinum.sentinel.databinding.SentinelItemLogBinding
+import com.infinum.sentinel.ui.shared.Constants.LOG_DATE_TIME_FORMAT
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -13,7 +14,7 @@ internal class LoggerAdapter(
     private val onClick: (SentinelFileTree.Entry) -> Unit
 ) : ListAdapter<SentinelFileTree.Entry, LoggerViewHolder>(LoggerDiffUtil()) {
 
-    private val dateTimeFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss. SSSZ", Locale.getDefault())
+    private val dateTimeFormat = SimpleDateFormat(LOG_DATE_TIME_FORMAT, Locale.getDefault())
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): LoggerViewHolder =
         LoggerViewHolder(

--- a/tool-timber/src/main/kotlin/com/infinum/sentinel/ui/logger/LoggerViewHolder.kt
+++ b/tool-timber/src/main/kotlin/com/infinum/sentinel/ui/logger/LoggerViewHolder.kt
@@ -14,7 +14,11 @@ internal class LoggerViewHolder(
     private val binding: SentinelItemLogBinding
 ) : RecyclerView.ViewHolder(binding.root) {
 
-    fun bind(item: SentinelFileTree.Entry?, onClick: (SentinelFileTree.Entry) -> Unit) {
+    fun bind(
+        item: SentinelFileTree.Entry?,
+        dateTimeFormat: SimpleDateFormat,
+        onClick: (SentinelFileTree.Entry) -> Unit
+    ) {
         item?.let { entry ->
             with(binding) {
                 levelView.setBackgroundColor(
@@ -31,7 +35,7 @@ internal class LoggerViewHolder(
                         }
                     )
                 )
-                timestampView.text = SimpleDateFormat.getDateTimeInstance().format(Date(entry.timestamp))
+                timestampView.text = dateTimeFormat.format(Date(entry.timestamp))
                 tagView.text = entry.tag
                 entry.stackTrace?.let {
                     stackTraceView.text = it

--- a/tool-timber/src/main/kotlin/com/infinum/sentinel/ui/logger/models/BaseEntry.kt
+++ b/tool-timber/src/main/kotlin/com/infinum/sentinel/ui/logger/models/BaseEntry.kt
@@ -1,6 +1,7 @@
 package com.infinum.sentinel.ui.logger.models
 
-import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
 import org.json.JSONObject
 
 internal open class BaseEntry(
@@ -10,7 +11,6 @@ internal open class BaseEntry(
     open val message: String? = null,
     open val stackTrace: String? = null
 ) {
-
     fun asJSONString(): String =
         JSONObject()
             .put("level", level)
@@ -20,9 +20,9 @@ internal open class BaseEntry(
             .put("stackTrace", stackTrace)
             .toString()
 
-    fun asLineString(): String =
+    fun asLineString(dateTimeFormat: SimpleDateFormat): String =
         buildString {
-            append(timestamp)
+            append(dateTimeFormat.format(Date(timestamp)))
             append(" LEVEL: ")
             append(level)
             append(" TAG: ")

--- a/tool-timber/src/main/kotlin/com/infinum/sentinel/ui/logger/models/FlowBuffer.kt
+++ b/tool-timber/src/main/kotlin/com/infinum/sentinel/ui/logger/models/FlowBuffer.kt
@@ -28,8 +28,8 @@ internal class FlowBuffer<T : BaseEntry> {
             } else {
                 queue.reversed().filter {
                     it.tag?.lowercase()?.contains(query.lowercase()) == true ||
-                            it.message?.lowercase()?.contains(query.lowercase()) == true ||
-                            it.stackTrace?.lowercase()?.contains(query.lowercase()) == true
+                        it.message?.lowercase()?.contains(query.lowercase()) == true ||
+                        it.stackTrace?.lowercase()?.contains(query.lowercase()) == true
                 }
             }
         )

--- a/tool-timber/src/main/kotlin/com/infinum/sentinel/ui/logs/LogsActivity.kt
+++ b/tool-timber/src/main/kotlin/com/infinum/sentinel/ui/logs/LogsActivity.kt
@@ -29,7 +29,6 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-
 public class LogsActivity : AppCompatActivity() {
 
     private companion object {
@@ -79,21 +78,21 @@ public class LogsActivity : AppCompatActivity() {
         with(binding) {
             toolbar.setNavigationOnClickListener { finish() }
             toolbar.subtitle = (
-                    packageManager.getApplicationLabel(
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                            packageManager.getApplicationInfo(
-                                packageName,
-                                PackageManager.ApplicationInfoFlags.of(PackageManager.GET_META_DATA.toLong())
-                            )
-                        } else {
-                            @Suppress("DEPRECATION")
-                            packageManager.getApplicationInfo(
-                                packageName,
-                                PackageManager.GET_META_DATA
-                            )
-                        }
-                    ) as? String
-                    ) ?: getString(R.string.sentinel_name)
+                packageManager.getApplicationLabel(
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                        packageManager.getApplicationInfo(
+                            packageName,
+                            PackageManager.ApplicationInfoFlags.of(PackageManager.GET_META_DATA.toLong())
+                        )
+                    } else {
+                        @Suppress("DEPRECATION")
+                        packageManager.getApplicationInfo(
+                            packageName,
+                            PackageManager.GET_META_DATA
+                        )
+                    }
+                ) as? String
+                ) ?: getString(R.string.sentinel_name)
 
             recyclerView.layoutManager = LinearLayoutManager(
                 recyclerView.context,

--- a/tool-timber/src/main/kotlin/com/infinum/sentinel/ui/logs/LogsAdapter.kt
+++ b/tool-timber/src/main/kotlin/com/infinum/sentinel/ui/logs/LogsAdapter.kt
@@ -4,6 +4,7 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
 import com.infinum.sentinel.databinding.SentinelItemLogFileBinding
+import com.infinum.sentinel.ui.shared.Constants.LOG_DATE_TIME_FORMAT
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -14,7 +15,7 @@ internal class LogsAdapter(
     private val onShare: (File) -> Unit
 ) : ListAdapter<File, LogsViewHolder>(LogsDiffUtil()) {
 
-    private val dateTimeFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss. SSSZ", Locale.getDefault())
+    private val dateTimeFormat = SimpleDateFormat(LOG_DATE_TIME_FORMAT, Locale.getDefault())
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): LogsViewHolder =
         LogsViewHolder(

--- a/tool-timber/src/main/kotlin/com/infinum/sentinel/ui/logs/LogsAdapter.kt
+++ b/tool-timber/src/main/kotlin/com/infinum/sentinel/ui/logs/LogsAdapter.kt
@@ -3,16 +3,18 @@ package com.infinum.sentinel.ui.logs
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
-import com.infinum.sentinel.SentinelFileTree
-import com.infinum.sentinel.databinding.SentinelItemLogBinding
 import com.infinum.sentinel.databinding.SentinelItemLogFileBinding
 import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 internal class LogsAdapter(
     private val onListChanged: (Boolean) -> Unit,
     private val onDelete: (File) -> Unit,
     private val onShare: (File) -> Unit
 ) : ListAdapter<File, LogsViewHolder>(LogsDiffUtil()) {
+
+    private val dateTimeFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss. SSSZ", Locale.getDefault())
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): LogsViewHolder =
         LogsViewHolder(
@@ -24,7 +26,12 @@ internal class LogsAdapter(
         )
 
     override fun onBindViewHolder(holder: LogsViewHolder, position: Int) {
-        holder.bind(getItem(position), onDelete, onShare)
+        holder.bind(
+            item = getItem(position),
+            dateTimeFormat = dateTimeFormat,
+            onDelete = onDelete,
+            onShare = onShare
+        )
     }
 
     override fun onViewRecycled(holder: LogsViewHolder) {

--- a/tool-timber/src/main/kotlin/com/infinum/sentinel/ui/logs/LogsViewHolder.kt
+++ b/tool-timber/src/main/kotlin/com/infinum/sentinel/ui/logs/LogsViewHolder.kt
@@ -1,12 +1,7 @@
 package com.infinum.sentinel.ui.logs
 
-import androidx.core.content.ContextCompat
-import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
-import com.infinum.sentinel.R
-import com.infinum.sentinel.SentinelFileTree
 import com.infinum.sentinel.databinding.SentinelItemLogFileBinding
-import com.infinum.sentinel.ui.logger.models.Level
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -15,11 +10,11 @@ internal class LogsViewHolder(
     private val binding: SentinelItemLogFileBinding
 ) : RecyclerView.ViewHolder(binding.root) {
 
-    fun bind(item: File?, onDelete: (File) -> Unit, onShare: (File) -> Unit) {
+    fun bind(item: File?, dateTimeFormat: SimpleDateFormat, onDelete: (File) -> Unit, onShare: (File) -> Unit) {
         item?.let { entry ->
             with(binding) {
                 messageView.text = entry.name
-                timestampView.text = SimpleDateFormat.getDateTimeInstance().format(Date(entry.lastModified()))
+                timestampView.text = dateTimeFormat.format(Date(entry.lastModified()))
                 deleteButton.setOnClickListener { onDelete(entry) }
                 shareButton.setOnClickListener { onShare(entry) }
             }

--- a/tool-timber/src/main/kotlin/com/infinum/sentinel/ui/shared/Constants.kt
+++ b/tool-timber/src/main/kotlin/com/infinum/sentinel/ui/shared/Constants.kt
@@ -1,0 +1,5 @@
+package com.infinum.sentinel.ui.shared
+
+internal object Constants {
+    const val LOG_DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+}


### PR DESCRIPTION


## :camera: Screenshots
![Screenshot_20240707_163138](https://github.com/infinum/android-sentinel/assets/20267231/e7e948ef-7c56-48ad-a70e-ed9d40d7cc0a)


## :page_facing_up: Context
As requested in https://github.com/infinum/android-sentinel/issues/47 exported logs now have human-readable timestamp (same format as logcat). Also, to have the consistency I added same date-time format to the list of logs (and log files)

## :pencil: Changes
Added date-time formating when writing logs to files. Changed date-time formatting in list of logs 

## :hammer_and_wrench: How to test
Try out sample app