### PR TITLE
Add sort to shared prefs tool

### DIFF
--- a/sentinel/src/main/kotlin/com/infinum/sentinel/data/models/raw/PreferencesData.kt
+++ b/sentinel/src/main/kotlin/com/infinum/sentinel/data/models/raw/PreferencesData.kt
@@ -2,5 +2,6 @@ package com.infinum.sentinel.data.models.raw
 
 internal data class PreferencesData(
     val name: String,
-    val values: List<Triple<PreferenceType, String, Any>>
+    val values: List<Triple<PreferenceType, String, Any>>,
+    val isSortedAscending: Boolean = false,
 )

--- a/sentinel/src/main/kotlin/com/infinum/sentinel/data/models/raw/PreferencesData.kt
+++ b/sentinel/src/main/kotlin/com/infinum/sentinel/data/models/raw/PreferencesData.kt
@@ -4,4 +4,5 @@ internal data class PreferencesData(
     val name: String,
     val values: List<Triple<PreferenceType, String, Any>>,
     val isSortedAscending: Boolean = false,
+    val isExpanded: Boolean = true,
 )

--- a/sentinel/src/main/kotlin/com/infinum/sentinel/data/sources/raw/collectors/PreferencesCollector.kt
+++ b/sentinel/src/main/kotlin/com/infinum/sentinel/data/sources/raw/collectors/PreferencesCollector.kt
@@ -29,6 +29,8 @@ internal class PreferencesCollector(
                 prefsDirectory.list().orEmpty().toList().map { it.removeSuffix(PREFS_SUFFIX) }
             } else {
                 listOf()
+            }.sortedBy { name ->
+                name
             }.map { name ->
                 val allPrefs = getSharedPreferences(name, MODE_PRIVATE).all
                 val tuples = allPrefs.keys.toSet().mapNotNull {

--- a/sentinel/src/main/kotlin/com/infinum/sentinel/ui/main/preferences/PreferencesFragment.kt
+++ b/sentinel/src/main/kotlin/com/infinum/sentinel/ui/main/preferences/PreferencesFragment.kt
@@ -88,23 +88,23 @@ internal class PreferencesFragment :
             }.root
 
     private fun SentinelViewItemPreferenceBinding.showPreferenceData(data: PreferencesData) {
-        data.values.forEach { tuple ->
+        data.values.forEach { (preferenceType, label, value) ->
             prefsLayout.addView(
                 SentinelViewItemTextBinding.inflate(layoutInflater, prefsLayout, false)
                     .apply {
                         labelView.isAllCaps = false
-                        labelView.text = tuple.second
-                        valueView.text = tuple.third.toString()
+                        labelView.text = label
+                        valueView.text = value.toString()
                         root.setOnClickListener { _ ->
                             viewModel.cache(
-                                data.name,
-                                tuple
+                                name = data.name,
+                                tuple = Triple(preferenceType, label, value)
                             )
                         }
                         root.setOnLongClickListener {
                             it.context.copyToClipboard(
-                                key = tuple.second,
-                                value = tuple.third.toString()
+                                key = label,
+                                value = value.toString()
                             )
                         }
                     }.root

--- a/sentinel/src/main/kotlin/com/infinum/sentinel/ui/main/preferences/PreferencesFragment.kt
+++ b/sentinel/src/main/kotlin/com/infinum/sentinel/ui/main/preferences/PreferencesFragment.kt
@@ -77,10 +77,12 @@ internal class PreferencesFragment :
 
                 if (data.isExpanded) {
                     prefsLayout.visibility = View.VISIBLE
+                    sortImageView.visibility = View.VISIBLE
                     hideExpandImageView.setImageResource(R.drawable.sentinel_ic_minus)
                     showPreferenceData(data)
                 } else {
                     prefsLayout.visibility = View.GONE
+                    sortImageView.visibility = View.GONE
                     hideExpandImageView.setImageResource(R.drawable.sentinel_ic_plus)
                 }
             }.root

--- a/sentinel/src/main/kotlin/com/infinum/sentinel/ui/main/preferences/PreferencesFragment.kt
+++ b/sentinel/src/main/kotlin/com/infinum/sentinel/ui/main/preferences/PreferencesFragment.kt
@@ -69,6 +69,9 @@ internal class PreferencesFragment :
         SentinelViewItemPreferenceBinding.inflate(layoutInflater, binding.contentLayout, false)
             .apply {
                 nameView.text = data.name
+                sortImageView.setOnClickListener {
+                    viewModel.onSortClicked(data)
+                }
                 data.values.forEach { tuple ->
                     prefsLayout.addView(
                         SentinelViewItemTextBinding.inflate(layoutInflater, prefsLayout, false)

--- a/sentinel/src/main/kotlin/com/infinum/sentinel/ui/main/preferences/PreferencesFragment.kt
+++ b/sentinel/src/main/kotlin/com/infinum/sentinel/ui/main/preferences/PreferencesFragment.kt
@@ -64,7 +64,6 @@ internal class PreferencesFragment :
             }
         }
 
-    @Suppress("UNCHECKED_CAST")
     private fun createItemView(data: PreferencesData): View =
         SentinelViewItemPreferenceBinding.inflate(layoutInflater, binding.contentLayout, false)
             .apply {
@@ -72,27 +71,42 @@ internal class PreferencesFragment :
                 sortImageView.setOnClickListener {
                     viewModel.onSortClicked(data)
                 }
-                data.values.forEach { tuple ->
-                    prefsLayout.addView(
-                        SentinelViewItemTextBinding.inflate(layoutInflater, prefsLayout, false)
-                            .apply {
-                                labelView.isAllCaps = false
-                                labelView.text = tuple.second
-                                valueView.text = tuple.third.toString()
-                                root.setOnClickListener { _ ->
-                                    viewModel.cache(
-                                        data.name,
-                                        tuple
-                                    )
-                                }
-                                root.setOnLongClickListener {
-                                    it.context.copyToClipboard(
-                                        key = tuple.second,
-                                        value = tuple.third.toString()
-                                    )
-                                }
-                            }.root
-                    )
+                hideExpandImageView.setOnClickListener {
+                    viewModel.onHideExpandClicked(data)
+                }
+
+                if (data.isExpanded) {
+                    prefsLayout.visibility = View.VISIBLE
+                    hideExpandImageView.setImageResource(R.drawable.sentinel_ic_minus)
+                    showPreferenceData(data)
+                } else {
+                    prefsLayout.visibility = View.GONE
+                    hideExpandImageView.setImageResource(R.drawable.sentinel_ic_plus)
                 }
             }.root
+
+    private fun SentinelViewItemPreferenceBinding.showPreferenceData(data: PreferencesData) {
+        data.values.forEach { tuple ->
+            prefsLayout.addView(
+                SentinelViewItemTextBinding.inflate(layoutInflater, prefsLayout, false)
+                    .apply {
+                        labelView.isAllCaps = false
+                        labelView.text = tuple.second
+                        valueView.text = tuple.third.toString()
+                        root.setOnClickListener { _ ->
+                            viewModel.cache(
+                                data.name,
+                                tuple
+                            )
+                        }
+                        root.setOnLongClickListener {
+                            it.context.copyToClipboard(
+                                key = tuple.second,
+                                value = tuple.third.toString()
+                            )
+                        }
+                    }.root
+            )
+        }
+    }
 }

--- a/sentinel/src/main/kotlin/com/infinum/sentinel/ui/main/preferences/PreferencesViewModel.kt
+++ b/sentinel/src/main/kotlin/com/infinum/sentinel/ui/main/preferences/PreferencesViewModel.kt
@@ -1,6 +1,7 @@
 package com.infinum.sentinel.ui.main.preferences
 
 import com.infinum.sentinel.data.models.raw.PreferenceType
+import com.infinum.sentinel.data.models.raw.PreferencesData
 import com.infinum.sentinel.domain.Factories
 import com.infinum.sentinel.domain.Repositories
 import com.infinum.sentinel.domain.preference.models.PreferenceParameters
@@ -38,4 +39,24 @@ internal class PreferencesViewModel(
             }
             emitEvent(PreferencesEvent.Cached())
         }
+
+    fun onSortClicked(data: PreferencesData) {
+        val currentValues = (stateFlow.value as? PreferencesState.Data)?.value.orEmpty()
+        val sortedData = if (data.isSortedAscending) {
+            data.values.sortedByDescending { it.second }
+        } else {
+            data.values.sortedBy { it.second }
+        }
+        val changedValues = currentValues.map { preferencesData ->
+            if (preferencesData.name == data.name) {
+                preferencesData.copy(
+                    values = sortedData,
+                    isSortedAscending = !preferencesData.isSortedAscending
+                )
+            } else {
+                preferencesData
+            }
+        }
+        setState(PreferencesState.Data(value = changedValues))
+    }
 }

--- a/sentinel/src/main/kotlin/com/infinum/sentinel/ui/main/preferences/PreferencesViewModel.kt
+++ b/sentinel/src/main/kotlin/com/infinum/sentinel/ui/main/preferences/PreferencesViewModel.kt
@@ -59,4 +59,20 @@ internal class PreferencesViewModel(
         }
         setState(PreferencesState.Data(value = changedValues))
     }
+
+    fun onHideExpandClicked(data: PreferencesData) {
+        (stateFlow.value as? PreferencesState.Data)?.let { state ->
+            val currentValues = state.value
+            val changedValues = currentValues.map { preferencesData ->
+                if (preferencesData.name == data.name) {
+                    preferencesData.copy(
+                        isExpanded = !preferencesData.isExpanded
+                    )
+                } else {
+                    preferencesData
+                }
+            }
+            setState(PreferencesState.Data(value = changedValues))
+        }
+    }
 }

--- a/sentinel/src/main/res/drawable/sentinel_ic_sort.xml
+++ b/sentinel/src/main/res/drawable/sentinel_ic_sort.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="?android:textColorSecondary"
+        android:pathData="M14.94,4.66h-4.72l2.36,-2.36zM10.25,19.37h4.66l-2.33,2.33zM6.1,6.27L1.6,17.73h1.84l0.92,-2.45h5.11l0.92,2.45h1.84L7.74,6.27L6.1,6.27zM4.97,13.64l1.94,-5.18 1.94,5.18L4.97,13.64zM15.73,16.14h6.12v1.59h-8.53v-1.29l5.92,-8.56h-5.88v-1.6h8.3v1.26l-5.93,8.6z" />
+
+</vector>

--- a/sentinel/src/main/res/layout/sentinel_view_item_preference.xml
+++ b/sentinel/src/main/res/layout/sentinel_view_item_preference.xml
@@ -10,7 +10,8 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        android:paddingBottom="8dp">
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/nameView"
@@ -22,6 +23,17 @@
             android:textColor="@color/sentinel_primary"
             tools:text="Preferences" />
 
+        <ImageView
+            android:id="@+id/hideExpandImageView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:contentDescription="@string/sentinel_hide_expands_the_preferences"
+            android:src="@drawable/sentinel_ic_plus" />
+
+        <View
+            android:layout_width="16dp"
+            android:layout_height="match_parent" />
 
         <ImageView
             android:id="@+id/sortImageView"

--- a/sentinel/src/main/res/layout/sentinel_view_item_preference.xml
+++ b/sentinel/src/main/res/layout/sentinel_view_item_preference.xml
@@ -1,18 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
     android:paddingStart="16dp"
     android:paddingEnd="16dp">
 
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/nameView"
-        style="@style/TextAppearance.Material3.BodySmall"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:textColor="@color/sentinel_primary" />
+        android:orientation="horizontal">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/nameView"
+            style="@style/TextAppearance.Material3.BodySmall"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:layout_weight="1"
+            android:textColor="@color/sentinel_primary"
+            tools:text="Preferences" />
+
+
+        <ImageView
+            android:id="@+id/sortImageView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:contentDescription="@string/sentinel_sort_preference_by_name"
+            android:src="@drawable/sentinel_ic_sort" />
+    </LinearLayout>
 
     <LinearLayout
         android:id="@+id/prefsLayout"

--- a/sentinel/src/main/res/layout/sentinel_view_item_preference.xml
+++ b/sentinel/src/main/res/layout/sentinel_view_item_preference.xml
@@ -24,6 +24,18 @@
             tools:text="Preferences" />
 
         <ImageView
+            android:id="@+id/sortImageView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:contentDescription="@string/sentinel_sort_preference_by_name"
+            android:src="@drawable/sentinel_ic_sort" />
+
+        <View
+            android:layout_width="16dp"
+            android:layout_height="match_parent" />
+
+        <ImageView
             android:id="@+id/hideExpandImageView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -31,17 +43,6 @@
             android:contentDescription="@string/sentinel_hide_expands_the_preferences"
             android:src="@drawable/sentinel_ic_plus" />
 
-        <View
-            android:layout_width="16dp"
-            android:layout_height="match_parent" />
-
-        <ImageView
-            android:id="@+id/sortImageView"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:contentDescription="@string/sentinel_sort_preference_by_name"
-            android:src="@drawable/sentinel_ic_sort" />
     </LinearLayout>
 
     <LinearLayout

--- a/sentinel/src/main/res/values/strings.xml
+++ b/sentinel/src/main/res/values/strings.xml
@@ -85,6 +85,7 @@
     <string name="sentinel_fragment_saved_state">Fragment Saved State</string>
 
     <string name="sentinel_sort_preference_by_name">Sort preferences by name</string>
+    <string name="sentinel_hide_expands_the_preferences">Hide/expands the preferences</string>
     <string name="sentinel_preferences_editor">Preferences editor</string>
     <string name="sentinel_key">Key</string>
     <string name="sentinel_current_value">Current value</string>

--- a/sentinel/src/main/res/values/strings.xml
+++ b/sentinel/src/main/res/values/strings.xml
@@ -84,6 +84,7 @@
     <string name="sentinel_fragment_arguments">Fragment arguments</string>
     <string name="sentinel_fragment_saved_state">Fragment Saved State</string>
 
+    <string name="sentinel_sort_preference_by_name">Sort preferences by name</string>
     <string name="sentinel_preferences_editor">Preferences editor</string>
     <string name="sentinel_key">Key</string>
     <string name="sentinel_current_value">Current value</string>

--- a/sentinel/src/main/res/values/strings.xml
+++ b/sentinel/src/main/res/values/strings.xml
@@ -85,7 +85,7 @@
     <string name="sentinel_fragment_saved_state">Fragment Saved State</string>
 
     <string name="sentinel_sort_preference_by_name">Sort preferences by name</string>
-    <string name="sentinel_hide_expands_the_preferences">Hide/expands the preferences</string>
+    <string name="sentinel_hide_expands_the_preferences">Hide/expand the preferences</string>
     <string name="sentinel_preferences_editor">Preferences editor</string>
     <string name="sentinel_key">Key</string>
     <string name="sentinel_current_value">Current value</string>


### PR DESCRIPTION
## :camera: Screenshots
Check out video in comments down below

## :page_facing_up: Context
Requested in https://github.com/infinum/android-sentinel/issues/44.
I added a sort by key to shared preferences tools. Worth keeping in mind that tool works in a way that separates each prefs file in UI (for example encrypted shared prefs are not mixed with normal shared prefs - check out video). 

## :pencil: Changes
I added:

- Icon and related listener to sort prefs on click
- Each prefs file is sorted separately by key
- If user clicks on sort multiple times sort will change from ascending to descending (for that I added additional field to related data class) 
- Option to expand/hide each preferences (file)
- Preferences are sorted based on file name

## :hammer_and_wrench: How to test
Run sample app or any other app that uses Sentinel. Worth noting that you might need to set some shared prefs.