### PR TITLE
Fix: exported component access should be restricted with appropriate permissions

### DIFF
--- a/sentinel/src/main/AndroidManifest.xml
+++ b/sentinel/src/main/AndroidManifest.xml
@@ -3,6 +3,10 @@
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
+    <permission
+        android:name="com.infinum.sentinel.permission.ACCESS_SENTINEL"
+        android:protectionLevel="signature" />
+
     <application>
 
         <activity
@@ -10,8 +14,9 @@
             android:exported="true"
             android:label="@string/sentinel_name"
             android:taskAffinity="com.infinum.sentinel"
-            android:theme="@style/Sentinel.Theme">
-            <meta-data
+            android:theme="@style/Sentinel.Theme"
+            android:permission="com.infinum.sentinel.permission.ACCESS_SENTINEL">
+        <meta-data
                 android:name="@string/sentinel_infinum_monitored"
                 android:value="false" />
         </activity>

--- a/tool-timber/src/main/kotlin/com/infinum/sentinel/SentinelFileTree.kt
+++ b/tool-timber/src/main/kotlin/com/infinum/sentinel/SentinelFileTree.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import com.infinum.sentinel.ui.logger.models.BaseEntry
 import com.infinum.sentinel.ui.logger.models.FlowBuffer
 import com.infinum.sentinel.ui.logger.models.Level
-import com.infinum.sentinel.ui.shared.Constants.LOG_DATE_TIME_FORMAT
+import com.infinum.sentinel.ui.shared.TimberToolConstants.LOG_DATE_TIME_FORMAT
 import com.infinum.sentinel.ui.shared.LogFileResolver
 import java.io.File
 import java.text.SimpleDateFormat

--- a/tool-timber/src/main/kotlin/com/infinum/sentinel/ui/logger/LoggerAdapter.kt
+++ b/tool-timber/src/main/kotlin/com/infinum/sentinel/ui/logger/LoggerAdapter.kt
@@ -5,7 +5,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
 import com.infinum.sentinel.SentinelFileTree
 import com.infinum.sentinel.databinding.SentinelItemLogBinding
-import com.infinum.sentinel.ui.shared.Constants.LOG_DATE_TIME_FORMAT
+import com.infinum.sentinel.ui.shared.TimberToolConstants.LOG_DATE_TIME_FORMAT
 import java.text.SimpleDateFormat
 import java.util.Locale
 

--- a/tool-timber/src/main/kotlin/com/infinum/sentinel/ui/logs/LogsAdapter.kt
+++ b/tool-timber/src/main/kotlin/com/infinum/sentinel/ui/logs/LogsAdapter.kt
@@ -4,7 +4,7 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
 import com.infinum.sentinel.databinding.SentinelItemLogFileBinding
-import com.infinum.sentinel.ui.shared.Constants.LOG_DATE_TIME_FORMAT
+import com.infinum.sentinel.ui.shared.TimberToolConstants.LOG_DATE_TIME_FORMAT
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Locale

--- a/tool-timber/src/main/kotlin/com/infinum/sentinel/ui/shared/TimberToolConstants.kt
+++ b/tool-timber/src/main/kotlin/com/infinum/sentinel/ui/shared/TimberToolConstants.kt
@@ -1,5 +1,5 @@
 package com.infinum.sentinel.ui.shared
 
-internal object Constants {
+internal object TimberToolConstants {
     const val LOG_DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
 }


### PR DESCRIPTION
## :page_facing_up: Context
[Sonar reported issue](https://sonarcloud.io/project/issues?id=infinum_android-sentinel&issues=AY69dgmkqpIEknBs3OF1&open=AY69dgmkqpIEknBs3OF1&tab=code)
This PR fixes that issue.
Feel free to add an additional review(s)

## :pencil: Changes
Since Sentinel activity is marked as `android:exported="true"` other apps can start that activity. And that is good, this is one of the ideas for Sentinel. Sonar finds this potential security issue because we don't define a mechanism by which apps that can open Sentinel should be "restricted".
To improve upon this I added custom permission that has `protectionLevel` **signature**. Meaning: only apps that are signed with the same certificate as Sentinel will be able to start Sentinel. This is perfect for our use case because Sentinel comes with apps.

Also, I ran into some compilation issues due to all modules/tools using the same package so I renamed one constant object in the Timber tool. Since this PR is not big I squeezed those changes here.

## :hammer_and_wrench: How to test
There's not much here, just try opening Sentinel in one app that uses lib.