### PR TITLE
Add gradle tasks for updating version in readme

### DIFF
--- a/sentinel/build.gradle
+++ b/sentinel/build.gradle
@@ -126,3 +126,7 @@ project.gradle.taskGraph.whenReady {
         ignoreFailures = true
     }
 }
+
+apply from: '../tasks.gradle'
+preBuild.dependsOn ':sentinel:generateReadme'
+

--- a/tasks.gradle
+++ b/tasks.gradle
@@ -1,0 +1,13 @@
+apply from: '../config.gradle'
+
+private void replaceVersionsInFile(File file) {
+    def content = file.text
+    content = content.replaceAll(~/sentinelVersion\s*=\s*".*"/, "sentinelVersion = \"${releaseConfig.version}\"")
+    file.setText(content)
+}
+
+tasks.register('generateReadme') {
+    doFirst {
+        replaceVersionsInFile(new File("${rootDir}/README.md"))
+    }
+}


### PR DESCRIPTION
When you change version in `config.gradle` and build sentinel module, task will be executed which will automatically update version in README. You can try it out for yourself.
Little something I borrowed from Prince of Version