### PR TITLE
Track public API changes 

### DIFF
--- a/apiComparison.gradle
+++ b/apiComparison.gradle
@@ -1,0 +1,51 @@
+tasks.register("compareSentinelApis") {
+    doFirst {
+        def sentinelApi = file("${project.rootDir}/sentinel/api/sentinel.api")
+        def noOpApi = file("${project.rootDir}/sentinel-no-op/api/sentinel-no-op.api")
+
+        if (!sentinelApi.exists() || !noOpApi.exists()) {
+            throw new GradleException("API dump files not found. Run `apiDump` task first.")
+        }
+
+        def targetBlocks = [
+                "public final class com/infinum/sentinel/Sentinel {",
+                "public final class com/infinum/sentinel/SentinelInitializer {",
+                "public abstract interface class com/infinum/sentinel/Sentinel\$Tool {"
+        ]
+
+        def extractRelevantLines = { File apiFile ->
+            def relevantLines = [] as Set
+            def insideTargetBlock = false
+
+            apiFile.eachLine { line ->
+                def trimmed = line.trim()
+
+                if (targetBlocks.contains(trimmed)) {
+                    insideTargetBlock = true
+                }
+
+                if (insideTargetBlock) {
+                    relevantLines.add(line)
+                }
+
+                if (trimmed.isEmpty()) {
+                    insideTargetBlock = false
+                }
+            }
+            return relevantLines
+        }
+
+        def sentinelRelevant = extractRelevantLines(sentinelApi)
+        def noOpRelevant = extractRelevantLines(noOpApi)
+
+        def missingLines = sentinelRelevant - noOpRelevant
+
+        if (!missingLines.isEmpty()) {
+            println "🚨 API mismatch detected! The following APIs in `Sentinel` are missing in `Sentinel no-op`:"
+            missingLines.each { println "❌ $it" }
+            throw new GradleException("API mismatch detected between Sentinel and Sentinel no-op!")
+        } else {
+            println "✅ API is identical between Sentinel and Sentinel no-op!"
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,17 @@ subprojects {
     apply from: "$rootDir/dokka.gradle"
 }
 
+gradle.projectsEvaluated {
+    subprojects { subproject ->
+        def apiCheckTask = subproject.tasks.findByName("apiCheck")
+        if (apiCheckTask != null) {
+            subproject.tasks.matching { it.name.startsWith("publish") }.all { publishTask ->
+                publishTask.dependsOn apiCheckTask
+            }
+        }
+    }
+}
+
 apply from: "deploy.gradle"
 
 tasks.withType(JavaCompile) {

--- a/sentinel-no-op/api/sentinel-no-op.api
+++ b/sentinel-no-op/api/sentinel-no-op.api
@@ -5,7 +5,8 @@ public final class com/infinum/sentinel/Sentinel {
 	public static final fun show ()V
 	public static final fun watch ()Lcom/infinum/sentinel/Sentinel;
 	public static final fun watch (Ljava/util/Set;)Lcom/infinum/sentinel/Sentinel;
-	public static synthetic fun watch$default (Ljava/util/Set;ILjava/lang/Object;)Lcom/infinum/sentinel/Sentinel;
+	public static final fun watch (Ljava/util/Set;Ljava/util/Map;)Lcom/infinum/sentinel/Sentinel;
+	public static synthetic fun watch$default (Ljava/util/Set;Ljava/util/Map;ILjava/lang/Object;)Lcom/infinum/sentinel/Sentinel;
 }
 
 public abstract interface class com/infinum/sentinel/Sentinel$AnalyticsTool : com/infinum/sentinel/Sentinel$Tool {

--- a/sentinel/api/sentinel.api
+++ b/sentinel/api/sentinel.api
@@ -12,7 +12,8 @@ public final class com/infinum/sentinel/Sentinel {
 	public static final fun show ()V
 	public static final fun watch ()Lcom/infinum/sentinel/Sentinel;
 	public static final fun watch (Ljava/util/Set;)Lcom/infinum/sentinel/Sentinel;
-	public static synthetic fun watch$default (Ljava/util/Set;ILjava/lang/Object;)Lcom/infinum/sentinel/Sentinel;
+	public static final fun watch (Ljava/util/Set;Ljava/util/Map;)Lcom/infinum/sentinel/Sentinel;
+	public static synthetic fun watch$default (Ljava/util/Set;Ljava/util/Map;ILjava/lang/Object;)Lcom/infinum/sentinel/Sentinel;
 }
 
 public abstract interface class com/infinum/sentinel/Sentinel$AnalyticsTool : com/infinum/sentinel/Sentinel$Tool {
@@ -310,11 +311,15 @@ public final class com/infinum/sentinel/databinding/SentinelFragmentPreferenceEd
 }
 
 public final class com/infinum/sentinel/databinding/SentinelFragmentPreferencesBinding : androidx/viewbinding/ViewBinding {
-	public final field contentLayout Landroid/widget/LinearLayout;
+	public final field allPreferences Lcom/google/android/material/button/MaterialButton;
+	public final field container Landroidx/constraintlayout/widget/ConstraintLayout;
+	public final field emptyStateMessage Landroid/widget/TextView;
 	public final field nestedScrollView Landroidx/core/widget/NestedScrollView;
+	public final field recyclerView Landroidx/recyclerview/widget/RecyclerView;
+	public final field toolbar Lcom/google/android/material/appbar/MaterialToolbar;
 	public static fun bind (Landroid/view/View;)Lcom/infinum/sentinel/databinding/SentinelFragmentPreferencesBinding;
 	public synthetic fun getRoot ()Landroid/view/View;
-	public fun getRoot ()Landroidx/core/widget/NestedScrollView;
+	public fun getRoot ()Landroidx/coordinatorlayout/widget/CoordinatorLayout;
 	public static fun inflate (Landroid/view/LayoutInflater;)Lcom/infinum/sentinel/databinding/SentinelFragmentPreferencesBinding;
 	public static fun inflate (Landroid/view/LayoutInflater;Landroid/view/ViewGroup;Z)Lcom/infinum/sentinel/databinding/SentinelFragmentPreferencesBinding;
 }

--- a/sentinel/build.gradle
+++ b/sentinel/build.gradle
@@ -131,3 +131,10 @@ project.gradle.taskGraph.whenReady {
 apply from: '../tasks.gradle'
 preBuild.dependsOn ':sentinel:generateReadme'
 
+apply from:'../apiComparison.gradle'
+afterEvaluate {
+    tasks.named("apiCheck").configure {
+        dependsOn("compareSentinelApis")
+    }
+}
+


### PR DESCRIPTION
## Summary

To avoid mistakes like https://github.com/infinum/android-sentinel/releases/tag/1.5.1 I improved tracking of public API changes.

## Changes

1. new API dump with https://github.com/Kotlin/binary-compatibility-validator -> from now on this will be mandatory to pass publish task, because of:
2. all publishing tasks have dependency on `apiCheck`. This way we will force dev to update API with `apiDump`. And hopefully they will be aware of changes
3. I also added custom Gradle tasks to compare Sentine and Sentinel no-op APIs. It is not the most bulletproof version because of differences in API will always exist. But we will check for main classes (Sentinel, SentinelInitializer, Sentinel.Tool)

### Type

- [ ] **Feature**: This pull request introduces a new feature.
- [ ] **Bug fix**: This pull request fixes a bug.
- [ ] **Refactor**: This pull request refactors existing code.
- [ ] **Documentation**: This pull request updates documentation.
- [x] **Other**: This pull request makes other changes.

#### Additional information

How to test:
You can make change to Sentinel API (ex. watch, add new param with default value test: Int = 1) to simulate changes. Then try to publish change to mavenLocal.
It should fail. First because you need to do new API dump. And second time because there is diff between Sentinel and noop version APIs

### Description

Take a look at changes.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have tested my changes, including edge cases.
- [ ] I have added necessary tests for the changes introduced (if applicable).
- [ ] I have updated the documentation to reflect my changes (if applicable).

## Additional notes

<!--
    Add any additional comments, instructions, or insights about this pull request.
-->
